### PR TITLE
Highlight David Handley's siblings and add Alex biography

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ After running the script open `site/index.html` in your browser. Click a child
 to drill down into their branch, then use the links on each page to continue
 through the family tree or return to the main page.
 
+## Updating Word Biographies
+
+The `.docx` biographies stored in the repository can be edited directly without
+re-running the site generator. To update them:
+
+1. Copy the document you want to change from the repository to your computer.
+2. Make the edits in Microsoft Word (or another editor that can save `.docx`
+   files) and save the file with the same name.
+3. Replace the original file in the repository with your updated version.
+4. Stage and commit the change so the new document is tracked in version
+   control.
+
+You can also add new biographies by dropping additional `.docx` files into the
+repository and committing them. Keeping the filenames descriptive (for example,
+`First Last.docx`) makes them easier to locate later.
+
 ## Continuous Deployment
 
 Pushing to the `main` branch automatically rebuilds the site with GitHub

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -90,6 +90,42 @@ header h1 {
 .empty {
     color: #9aa5b1;
 }
+.ancestry-section {
+    margin-top: 3rem;
+}
+
+.ancestry-section h2 {
+    margin-bottom: 1rem;
+}
+
+.ancestry-intro {
+    margin-bottom: 1.5rem;
+}
+
+.ancestry-intro p {
+    margin: 0.5rem 0;
+    line-height: 1.6;
+}
+
+.ancestry-lead {
+    margin: 0 0 1.5rem;
+    color: #52606d;
+}
+
+.siblings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+
+.sibling-card h3 {
+    margin-bottom: 0.5rem;
+}
+
+.sibling-card p {
+    margin: 0.4rem 0;
+    line-height: 1.55;
+}
 @media (max-width: 720px) {
     .base-layout {
         flex-direction: column;

--- a/site/index.html
+++ b/site/index.html
@@ -23,6 +23,42 @@
                 </div>
             </div>
         </section>
+        <section class='ancestry-section' id='david-handley-siblings'>
+            <h2>Family Roots</h2>
+            <div class='person-card ancestry-intro'>
+                <p><strong>Father:</strong> <a href='people/alex-handley-I106254684.html'>Alex Handley</a> (c. 1892 &ndash; 5 Apr 1959, Little Rock, Pulaski County, Arkansas)</p>
+                <p><strong>Mother:</strong> Jester Ann Pegross (Feb 1891 &ndash; Mar 1977, Tillar, Desha County, Arkansas)</p>
+                <p>Alex and Jester Ann settled in Jefferson County, Arkansas, where they raised David and his siblings in the Tillar community.</p>
+            </div>
+            <p class='ancestry-lead'>David grew up alongside five siblings. These brief profiles highlight the paths each of them took.</p>
+            <div class='siblings-grid'>
+                <div class='person-card sibling-card'>
+                    <h3>Alex Handley (c.1911&ndash;1938)</h3>
+                    <p>Born in Louisiana, Alex was the eldest son in the family.</p>
+                    <p>He was recorded with the household in Jefferson County, Arkansas in 1930 and passed away in nearby Drew County on 29 July 1938.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Jimmie Handley (c.1914&ndash;1995)</h3>
+                    <p>Jimmie spent his early years in Louisiana before joining the family in Jefferson County, Arkansas.</p>
+                    <p>He later made his home in Tillar and died in Saint Anne, Illinois in August 1995.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Mollie Handley (c.1917&ndash;1991)</h3>
+                    <p>Mollie was born in Louisiana and appeared in the family&rsquo;s Jefferson County household in 1930.</p>
+                    <p>By 1940 she was living in Winchester, Drew County, Arkansas, where she remained until her death in September 1991.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Joshua Handley (c.1918&ndash;1993)</h3>
+                    <p>Joshua also grew up in the Jefferson County household after his birth in Louisiana.</p>
+                    <p>He later moved north and passed away in Chicago, Illinois on 6 March 1993.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Leola Handley (1921&ndash;2005)</h3>
+                    <p>Leola was born on 23 September 1921 and remained close to the family.</p>
+                    <p>She was living in McGehee, Arkansas by the mid-1980s and died there on 9 June 2005.</p>
+                </div>
+            </div>
+        </section>
     </div>
 </body>
 </html>

--- a/site/people/alex-handley-I106254684.html
+++ b/site/people/alex-handley-I106254684.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+    <meta charset='utf-8'>
+    <title>Alex Handley &mdash; Family Tree</title>
+    <link rel='stylesheet' href='../assets/styles.css'>
+</head>
+<body>
+    <div class='container'>
+        <header class='page-header'>
+            <h1>Alex Handley</h1>
+        </header>
+        <section class='person-details'>
+            <p><strong>Born:</strong> c. 1892, Louisiana, USA</p>
+            <p><strong>Died:</strong> 5 Apr 1959, Little Rock, Pulaski County, Arkansas, USA</p>
+            <p><strong>Spouse(s):</strong> Jester Ann Pegross</p>
+            <p><a href='../index.html'>&larr; Back to David and Verna</a></p>
+        </section>
+        <section class='person-biography'>
+            <h2>History</h2>
+            <p>Alex Handley was born about 1892 in Louisiana. Records from the Selective Service and the 1930 census show him leading his household after relocating to Jefferson County, Arkansas.</p>
+            <p>He married Jester Ann Pegross, who was born in February 1891 in Louisiana, and together they raised their family in the Tillar community of Desha County. Their home included children Alex Jr., Jimmie, David, Mollie, Joshua, and Leola, each of whom carried the Handley name into the next generation.</p>
+            <p>Alex died on 5 April 1959 in Little Rock, Arkansas, while Jester Ann lived until March 1977 in Tillar. Their story anchors the Handley family&rsquo;s transition from Louisiana roots to a lasting presence in Arkansas.</p>
+        </section>
+        <section class='person-children'>
+            <h2>Children</h2>
+            <div class='children-grid'>
+                <div class='person-card'>
+                    <h4>Alex Handley</h4>
+                    <p><strong>Born:</strong> c. 1911, Louisiana, USA</p>
+                    <p><strong>Died:</strong> 29 Jul 1938, Drew County, Arkansas</p>
+                </div>
+                <div class='person-card'>
+                    <h4>Jimmie Handley</h4>
+                    <p><strong>Born:</strong> c. 1914, Louisiana, USA</p>
+                    <p><strong>Died:</strong> Aug 1995, Saint Anne, Kankakee County, Illinois, USA</p>
+                </div>
+                <div class='person-card'>
+                    <h4>David Handley</h4>
+                    <p><strong>Born:</strong> 10 May 1915, Bastrop, Morehouse Parish, Louisiana, USA</p>
+                    <p><strong>Died:</strong> Dec 1988, Pine Bluff, Jefferson County, Arkansas, USA</p>
+                </div>
+                <div class='person-card'>
+                    <h4>Mollie Handley</h4>
+                    <p><strong>Born:</strong> c. 1917, Louisiana, USA</p>
+                    <p><strong>Died:</strong> Sep 1991, Winchester, Drew County, Arkansas, USA</p>
+                </div>
+                <div class='person-card'>
+                    <h4>Joshua Handley</h4>
+                    <p><strong>Born:</strong> c. 1918, Louisiana, USA</p>
+                    <p><strong>Died:</strong> 6 Mar 1993, Chicago, Cook County, Illinois, USA</p>
+                </div>
+                <div class='person-card'>
+                    <h4>Leola Handley</h4>
+                    <p><strong>Born:</strong> 23 Sep 1921</p>
+                    <p><strong>Died:</strong> 9 Jun 2005, McGehee, Desha County, Arkansas, USA</p>
+                </div>
+            </div>
+        </section>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Family Roots section on the home page that links to Alex Handley and introduces David Handley's siblings
- create a dedicated profile for Alex Handley with a concise history and summaries for each of his children
- document how to update the Word biography files for future content edits

## Testing
- no automated tests were run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3c7b49eb4832e9b3be0de6247f43d