### PR TITLE
Ensure generated site includes ancestry section and updated styles

### DIFF
--- a/generate_family_tree.py
+++ b/generate_family_tree.py
@@ -561,6 +561,42 @@ def render_index(
                 </div>
             </div>
         </section>
+        <section class='ancestry-section' id='david-handley-siblings'>
+            <h2>Family Roots</h2>
+            <div class='person-card ancestry-intro'>
+                <p><strong>Father:</strong> <a href='people/alex-handley-I106254684.html'>Alex Handley</a> (c. 1892 &ndash; 5 Apr 1959, Little Rock, Pulaski County, Arkansas)</p>
+                <p><strong>Mother:</strong> Jester Ann Pegross (Feb 1891 &ndash; Mar 1977, Tillar, Desha County, Arkansas)</p>
+                <p>Alex and Jester Ann settled in Jefferson County, Arkansas, where they raised David and his siblings in the Tillar community.</p>
+            </div>
+            <p class='ancestry-lead'>David grew up alongside five siblings. These brief profiles highlight the paths each of them took.</p>
+            <div class='siblings-grid'>
+                <div class='person-card sibling-card'>
+                    <h3>Alex Handley (c.1911&ndash;1938)</h3>
+                    <p>Born in Louisiana, Alex was the eldest son in the family.</p>
+                    <p>He was recorded with the household in Jefferson County, Arkansas in 1930 and passed away in nearby Drew County on 29 July 1938.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Jimmie Handley (c.1914&ndash;1995)</h3>
+                    <p>Jimmie spent his early years in Louisiana before joining the family in Jefferson County, Arkansas.</p>
+                    <p>He later made his home in Tillar and died in Saint Anne, Illinois in August 1995.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Mollie Handley (c.1917&ndash;1991)</h3>
+                    <p>Mollie was born in Louisiana and appeared in the family&rsquo;s Jefferson County household in 1930.</p>
+                    <p>By 1940 she was living in Winchester, Drew County, Arkansas, where she remained until her death in September 1991.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Joshua Handley (c.1918&ndash;1993)</h3>
+                    <p>Joshua also grew up in the Jefferson County household after his birth in Louisiana.</p>
+                    <p>He later moved north and passed away in Chicago, Illinois on 6 March 1993.</p>
+                </div>
+                <div class='person-card sibling-card'>
+                    <h3>Leola Handley (1921&ndash;2005)</h3>
+                    <p>Leola was born on 23 September 1921 and remained close to the family.</p>
+                    <p>She was living in McGehee, Arkansas by the mid-1980s and died there on 9 June 2005.</p>
+                </div>
+            </div>
+        </section>
     </div>
 </body>
 </html>
@@ -658,110 +694,10 @@ def render_descendant_page(
 
 
 def write_stylesheet(output_dir: Path) -> None:
-    css = """
-:root {
-    color-scheme: light;
-}
-body {
-    font-family: 'Segoe UI', Tahoma, sans-serif;
-    margin: 0;
-    background: #f3f4f6;
-    color: #1f2933;
-}
-a {
-    color: #1d4ed8;
-    text-decoration: none;
-}
-a:hover {
-    text-decoration: underline;
-}
-.container {
-    max-width: 1100px;
-    margin: 0 auto;
-    padding: 2.5rem 1.5rem 4rem;
-}
-header h1 {
-    margin-bottom: 0.25rem;
-}
-.lead {
-    color: #52606d;
-    margin-top: 0;
-}
-.base-layout {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    align-items: flex-start;
-}
-.base-column {
-    flex: 0 0 320px;
-    display: grid;
-    gap: 1.5rem;
-}
-.children-column {
-    flex: 1 1 360px;
-}
-.children-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
-}
-.person-card {
-    background: white;
-    border-radius: 10px;
-    padding: 1rem 1.2rem;
-    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
-    border: 1px solid rgba(15, 23, 42, 0.08);
-}
-.person-card h2,
-.person-card h3,
-.person-card h4 {
-    margin-top: 0;
-    margin-bottom: 0.25rem;
-}
-.person-card p {
-    margin: 0.15rem 0;
-}
-.person-card .meta {
-    color: #64748b;
-}
-.person-details {
-    margin-top: 2rem;
-}
-.person-details p {
-    font-size: 1rem;
-}
-.person-biography {
-    margin-top: 2rem;
-}
-.person-biography h2 {
-    margin-bottom: 0.5rem;
-}
-.person-biography p {
-    margin: 0.75rem 0;
-    line-height: 1.6;
-}
-.person-children {
-    margin-top: 2rem;
-}
-.person-children h2 {
-    margin-bottom: 0.75rem;
-}
-.empty {
-    color: #9aa5b1;
-}
-@media (max-width: 720px) {
-    .base-layout {
-        flex-direction: column;
-    }
-    .base-column {
-        width: 100%;
-    }
-    .children-column {
-        width: 100%;
-    }
-}
-"""
+    css_path = Path(__file__).resolve().with_name("styles.css")
+    if not css_path.exists():
+        raise FileNotFoundError(f"Expected stylesheet at {css_path}")
+    css = css_path.read_text(encoding="utf-8")
     write_file(output_dir / "assets" / "styles.css", css)
 
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,97 +1,136 @@
-
 :root {
     color-scheme: light;
 }
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, sans-serif;
     margin: 0;
     background: #f3f4f6;
     color: #1f2933;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
 }
+
 a {
     color: #1d4ed8;
     text-decoration: none;
 }
-a:hover {
+
+a:hover,
+a:focus-visible {
     text-decoration: underline;
 }
+
+img,
+svg {
+    max-width: 100%;
+    display: block;
+}
+
 .container {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 2.5rem 1.5rem 4rem;
+    padding: clamp(2rem, 2vw + 1.5rem, 3rem) clamp(1.25rem, 4vw, 3rem) clamp(3rem, 5vw, 4.5rem);
 }
+
+header {
+    margin-bottom: clamp(1.5rem, 4vw, 2.5rem);
+}
+
 header h1 {
-    margin-bottom: 0.25rem;
+    margin: 0 0 0.35rem;
+    font-size: clamp(2.1rem, 2vw + 1.6rem, 3rem);
 }
+
 .lead {
     color: #52606d;
-    margin-top: 0;
+    margin: 0;
+    max-width: 65ch;
+    font-size: clamp(1rem, 0.95rem + 0.4vw, 1.15rem);
 }
+
 .base-layout {
     display: flex;
     flex-wrap: wrap;
-    gap: 2rem;
+    gap: clamp(1.5rem, 2vw, 2.5rem);
     align-items: flex-start;
 }
+
 .base-column {
-    flex: 0 0 320px;
+    flex: 1 1 280px;
     display: grid;
     gap: 1.5rem;
 }
+
 .children-column {
-    flex: 1 1 360px;
+    flex: 2 1 380px;
 }
+
+.children-column > h2 {
+    margin-top: 0;
+}
+
 .children-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.1rem;
 }
+
 .person-card {
     background: white;
     border-radius: 10px;
-    padding: 1rem 1.2rem;
+    padding: 1rem 1.25rem;
     box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
     border: 1px solid rgba(15, 23, 42, 0.08);
 }
+
 .person-card h2,
 .person-card h3,
 .person-card h4 {
     margin-top: 0;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.4rem;
 }
+
 .person-card p {
-    margin: 0.15rem 0;
+    margin: 0.2rem 0;
 }
+
 .person-card .meta {
     color: #64748b;
 }
-.person-details {
-    margin-top: 2rem;
+
+.person-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: clamp(1.5rem, 2vw, 2.5rem);
+    align-items: flex-start;
 }
+
+.person-children {
+    flex: 1 1 260px;
+    order: -1;
+}
+
+.person-details {
+    flex: 2 1 420px;
+}
+
 .person-details p {
     font-size: 1rem;
 }
-.person-biography {
-    margin-top: 2rem;
-}
-.person-biography h2 {
-    margin-bottom: 0.5rem;
-}
-.person-biography p {
-    margin: 0.75rem 0;
-    line-height: 1.6;
-}
-.person-children {
-    margin-top: 2rem;
-}
-.person-children h2 {
-    margin-bottom: 0.75rem;
-}
+
 .empty {
     color: #9aa5b1;
 }
+
 .ancestry-section {
-    margin-top: 3rem;
+    margin-top: clamp(2.5rem, 4vw, 3.5rem);
 }
 
 .ancestry-section h2 {
@@ -126,14 +165,56 @@ header h1 {
     margin: 0.4rem 0;
     line-height: 1.55;
 }
+
+@media (max-width: 960px) {
+    .container {
+        padding: clamp(1.8rem, 2vw + 1.2rem, 2.5rem) clamp(1rem, 5vw, 2rem) clamp(3rem, 6vw, 4rem);
+    }
+}
+
 @media (max-width: 720px) {
-    .base-layout {
+    .base-layout,
+    .person-layout {
         flex-direction: column;
     }
-    .base-column {
+
+    .base-column,
+    .children-column,
+    .person-children,
+    .person-details {
         width: 100%;
     }
-    .children-column {
-        width: 100%;
+
+    .person-children {
+        order: 0;
+    }
+}
+
+@media (max-width: 540px) {
+    .container {
+        padding: 1.5rem 1rem 3rem;
+    }
+
+    header h1 {
+        font-size: clamp(1.8rem, 5vw, 2.3rem);
+    }
+
+    .children-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .person-card {
+        padding: 0.9rem 1rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -129,6 +129,43 @@ header h1 {
     color: #9aa5b1;
 }
 
+.ancestry-section {
+    margin-top: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.ancestry-section h2 {
+    margin-bottom: 1rem;
+}
+
+.ancestry-intro {
+    margin-bottom: 1.5rem;
+}
+
+.ancestry-intro p {
+    margin: 0.5rem 0;
+    line-height: 1.6;
+}
+
+.ancestry-lead {
+    margin: 0 0 1.5rem;
+    color: #52606d;
+}
+
+.siblings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+
+.sibling-card h3 {
+    margin-bottom: 0.5rem;
+}
+
+.sibling-card p {
+    margin: 0.4rem 0;
+    line-height: 1.55;
+}
+
 @media (max-width: 960px) {
     .container {
         padding: clamp(1.8rem, 2vw + 1.2rem, 2.5rem) clamp(1rem, 5vw, 2rem) clamp(3rem, 6vw, 4rem);


### PR DESCRIPTION
## Summary
- add the Family Roots ancestry section to the generated homepage template
- load the stylesheet from the checked-in styles.css so new classes are preserved in every build
- regenerate the published CSS so the ancestry styling and responsive tweaks ship with the site

## Testing
- python generate_family_tree.py handley.ged site

------
https://chatgpt.com/codex/tasks/task_e_68e3f6215f8c832e8debb911eea63c98